### PR TITLE
[#143876117] Tag instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ install:
 - true
 
 script:
+- go build -v . 
 - ./scripts/run-local-tests.sh
+
+

--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ This is a work-in-progress implementation of a service broker for services provi
    ```
    cf enable-service-access mongodb
    ```
+
+## Environmental variables
+
+`USERNAME` - broker user name used for basic authentication
+`PASSWORD` - username password
+`DB_PREFIX` - a prefix that can be used to tag instances. Defaults to `compose-broker`

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -113,7 +113,7 @@ func (b *Broker) Provision(context context.Context, instanceID string, details b
 
 	deployment, errs := b.Compose.CreateDeployment(params)
 	if len(errs) > 0 {
-		return spec, squashErrors(errs)
+		return spec, compose.SquashErrors(errs)
 	}
 
 	operationData, err := makeOperationData("provision", deployment.ProvisionRecipeID)
@@ -153,7 +153,7 @@ func (b *Broker) Deprovision(context context.Context, instanceID string, details
 
 	recipe, errs := b.Compose.DeprovisionDeployment(deployment.ID)
 	if len(errs) > 0 {
-		return spec, squashErrors(errs)
+		return spec, compose.SquashErrors(errs)
 	}
 
 	operationData, err := makeOperationData("deprovision", recipe.ID)
@@ -187,7 +187,7 @@ func (b *Broker) Bind(context context.Context, instanceID, bindingID string, det
 
 	deployment, errs := b.Compose.GetDeployment(deploymentMeta.ID)
 	if len(errs) > 0 {
-		return binding, squashErrors(errs)
+		return binding, compose.SquashErrors(errs)
 	}
 	if deployment.Connection.Direct == nil || len(deployment.Connection.Direct) < 1 {
 		return binding, fmt.Errorf("failed to get connection string")
@@ -273,7 +273,7 @@ func (b *Broker) Update(context context.Context, instanceID string, details brok
 
 	recipe, errs := b.Compose.SetScalings(params)
 	if len(errs) > 0 {
-		return spec, squashErrors(errs)
+		return spec, compose.SquashErrors(errs)
 	}
 
 	operationData, err := makeOperationData("update", recipe.ID)
@@ -302,7 +302,7 @@ func (b *Broker) LastOperation(context context.Context, instanceID, operationDat
 
 	recipe, errs := b.Compose.GetRecipe(operationData.RecipeID)
 	if len(errs) > 0 {
-		return lastOperation, squashErrors(errs)
+		return lastOperation, compose.SquashErrors(errs)
 	}
 
 	state := composeStatus2State[recipe.Status]

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -32,4 +32,16 @@ var _ = Describe("Broker", func() {
 			Expect(operationData).To(Equal(`{"recipe_id":"123","type":"expected_type"}`))
 		})
 	})
+	Describe("makeInstanceName", func() {
+		It("can make an instance name", func() {
+			instanceName, err := makeInstanceName("test", "15e332e8-4afa-4c41-82a3-f44b18eba448")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instanceName).To(Equal("test-15e332e8-4afa-4c41-82a3-f44b18eba448"))
+		})
+		It("can trim spaces from dbprefix", func() {
+			instanceName, err := makeInstanceName(" trim-spaces ", "0f38f9c2-085c-41ec-87bf-e38b72f7fdaa")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instanceName).To(Equal("trim-spaces-0f38f9c2-085c-41ec-87bf-e38b72f7fdaa"))
+		})
+	})
 })

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -1,22 +1,11 @@
 package broker
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Broker", func() {
-	Describe("squashErrors", func() {
-		It("can squash errors", func() {
-			errors := []error{
-				errors.New("first"),
-				errors.New("second"),
-			}
-			Expect(squashErrors(errors)).To(MatchError("first; second"))
-		})
-	})
 
 	Describe("JDBCURI", func() {
 		It("can create JDBC URI", func() {

--- a/broker/utils.go
+++ b/broker/utils.go
@@ -10,10 +10,10 @@ import (
 	composeapi "github.com/compose/gocomposeapi"
 )
 
-func findDeployment(compose compose.Client, name string) (*composeapi.Deployment, error) {
-	deployments, errs := compose.GetDeployments()
+func findDeployment(c compose.Client, name string) (*composeapi.Deployment, error) {
+	deployments, errs := c.GetDeployments()
 	if len(errs) > 0 {
-		return nil, squashErrors(errs)
+		return nil, compose.SquashErrors(errs)
 	}
 
 	for _, deployment := range *deployments {
@@ -23,16 +23,6 @@ func findDeployment(compose compose.Client, name string) (*composeapi.Deployment
 	}
 
 	return nil, fmt.Errorf("deployment: not found")
-}
-
-func squashErrors(errs []error) error {
-	var s []string
-
-	for _, err := range errs {
-		s = append(s, err.Error())
-	}
-
-	return fmt.Errorf("%s", strings.Join(s, "; "))
 }
 
 func JDBCURI(scheme, hostname, port, dbname, username, password string) string {

--- a/broker/utils.go
+++ b/broker/utils.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -51,4 +52,14 @@ func makeOperationData(operationType, recipeID string) (string, error) {
 	}
 
 	return string(data), nil
+}
+
+func makeInstanceName(dbPrefix, instanceID string) (string, error) {
+	if dbPrefix == "" {
+		return "", errors.New("dbPrefix can't be empty")
+	}
+	if instanceID == "" {
+		return "", errors.New("instanceID can't be empty")
+	}
+	return fmt.Sprintf("%s-%s", strings.TrimSpace(dbPrefix), instanceID), nil
 }

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -1,6 +1,9 @@
 package compose
 
 import (
+	"fmt"
+	"strings"
+
 	composeapi "github.com/compose/gocomposeapi"
 )
 
@@ -15,4 +18,14 @@ type Client interface {
 
 func NewClient(apiToken string) (*composeapi.Client, error) {
 	return composeapi.NewClient(apiToken)
+}
+
+func SquashErrors(errs []error) error {
+	var s []string
+
+	for _, err := range errs {
+		s = append(s, err.Error())
+	}
+
+	return fmt.Errorf("%s", strings.Join(s, "; "))
 }

--- a/compose/compose_suite_test.go
+++ b/compose/compose_suite_test.go
@@ -1,0 +1,13 @@
+package compose
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Broker Suite")
+}

--- a/compose/compose_test.go
+++ b/compose/compose_test.go
@@ -1,0 +1,20 @@
+package compose
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Compose", func() {
+	Describe("squashErrors", func() {
+		It("can squash errors", func() {
+			errors := []error{
+				errors.New("first"),
+				errors.New("second"),
+			}
+			Expect(SquashErrors(errors)).To(MatchError("first; second"))
+		})
+	})
+})

--- a/config/config.go
+++ b/config/config.go
@@ -54,11 +54,6 @@ func New() (*Config, error) {
 		return nil, fmt.Errorf("Please export $PASSWORD")
 	}
 
-	accountID := os.Getenv("ACCOUNT_ID")
-	if accountID == "" {
-		return nil, fmt.Errorf("Please export $ACCOUNT_ID")
-	}
-
 	token := os.Getenv("ACCESS_TOKEN")
 	if token == "" {
 		return nil, fmt.Errorf("Please export $ACCESS_TOKEN")
@@ -70,7 +65,6 @@ func New() (*Config, error) {
 	}
 
 	return &Config{
-		AccountID:  accountID,
 		APIToken:   token,
 		LogLevel:   logLevel,
 		ListenPort: listenPort,

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	ListenPort string
 	Username   string
 	Password   string
+	DBPrefix   string
 }
 
 func New() (*Config, error) {
@@ -63,6 +64,11 @@ func New() (*Config, error) {
 		return nil, fmt.Errorf("Please export $ACCESS_TOKEN")
 	}
 
+	dbPrefix := os.Getenv("DB_PREFIX")
+	if dbPrefix == "" {
+		dbPrefix = "compose-broker"
+	}
+
 	return &Config{
 		AccountID:  accountID,
 		APIToken:   token,
@@ -70,5 +76,6 @@ func New() (*Config, error) {
 		ListenPort: listenPort,
 		Username:   username,
 		Password:   password,
+		DBPrefix:   dbPrefix,
 	}, nil
 }

--- a/integration_tests/fake_api/broker_test.go
+++ b/integration_tests/fake_api/broker_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strconv"
 	"strings"
 
@@ -117,7 +116,7 @@ var _ = Describe("Broker with fake Compose client", func() {
 
 			expectedDeploymentParams := composeapi.DeploymentParams{
 				Name:         fmt.Sprintf("%s-%s", dbprefix, instanceID),
-				AccountID:    os.Getenv("ACCOUNT_ID"),
+				AccountID:    "",
 				Datacenter:   broker.ComposeDatacenter,
 				DatabaseType: "mongodb",
 				Units:        1,
@@ -148,7 +147,7 @@ var _ = Describe("Broker with fake Compose client", func() {
 
 			expectedDeploymentParams := composeapi.DeploymentParams{
 				Name:         fmt.Sprintf("%s-%s", dbprefix, instanceID),
-				AccountID:    os.Getenv("ACCOUNT_ID"),
+				AccountID:    "",
 				Datacenter:   broker.ComposeDatacenter,
 				DatabaseType: "mongodb",
 				Units:        1,

--- a/integration_tests/fake_api/broker_test.go
+++ b/integration_tests/fake_api/broker_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Broker with fake Compose client", func() {
 			Expect(string(body)).To(ContainSubstring(`{\"recipe_id\":\"provision-recipe-id\",\"type\":\"provision\"}`))
 		})
 
-		It("allows user provided parameters", func() {
+		It("ignores user provided parameters", func() {
 			path := "/v2/service_instances/" + instanceID
 			provisionDetailsJson := []byte(fmt.Sprintf(`{
 				  "service_id": "%s",
@@ -153,6 +153,8 @@ var _ = Describe("Broker with fake Compose client", func() {
 				DatabaseType: "mongodb",
 				Units:        1,
 				SSL:          true,
+				WiredTiger:   false,
+				Version:      "",
 			}
 			Expect(fakeComposeClient.CreateDeploymentParams).To(Equal(expectedDeploymentParams))
 			Expect(responseRecorder.Code).To(Equal(http.StatusAccepted))

--- a/integration_tests/fake_api/fake_api_suite_test.go
+++ b/integration_tests/fake_api/fake_api_suite_test.go
@@ -22,6 +22,7 @@ var (
 	brokerUrl  string
 	username   string
 	password   string
+	dbprefix   string
 	err        error
 )
 
@@ -36,9 +37,11 @@ func TestSuite(t *testing.T) {
 
 		username = randString(randLength)
 		password = randString(randLength)
+		dbprefix = randString(randLength)
 
 		os.Setenv("USERNAME", username)
 		os.Setenv("PASSWORD", password)
+		os.Setenv("DB_PREFIX", dbprefix)
 
 		newConfig, err = config.New()
 		Expect(err).ToNot(HaveOccurred())

--- a/integration_tests/real_api/compose_api_test.go
+++ b/integration_tests/real_api/compose_api_test.go
@@ -54,7 +54,6 @@ var _ = Describe("Broker with real Compose client", func() {
 		instanceID        string
 		bindingID         string
 		appGuid           string
-		paramJSON         string
 		acceptsIncomplete bool
 		data              bindingResponse
 	)
@@ -75,7 +74,6 @@ var _ = Describe("Broker with real Compose client", func() {
 		instanceID = uuid.NewV4().String()
 		bindingID = uuid.NewV4().String()
 		appGuid = uuid.NewV4().String()
-		paramJSON = "{}"
 		acceptsIncomplete = true
 	})
 
@@ -106,20 +104,15 @@ var _ = Describe("Broker with real Compose client", func() {
 	It("uses Compose API", func() {
 		By("provisioning an instance", func() {
 			path := "/v2/service_instances/" + instanceID
-			mongoVersion := "3.2.11"
 			provisionDetailsJson := []byte(fmt.Sprintf(`
 				{
 					"service_id": "%s",
 					"plan_id": "%s",
 					"organization_guid": "test-organization-id",
 					"space_guid": "space-id",
-					"parameters": {
-						"disable_ssl": true,
-						"wired_tiger": true,
-						"version": "%s"
-					}
+					"parameters": "{}"
 				}
-			`, serviceID, planID, mongoVersion))
+			`, serviceID, planID))
 			param := helper.UriParam{Key: "accepts_incomplete", Value: strconv.FormatBool(acceptsIncomplete)}
 			request := helper.NewRequest("PUT", path, bytes.NewBuffer(provisionDetailsJson), username, password, param)
 			brokerAPI.ServeHTTP(responseRecorder, request)
@@ -140,12 +133,11 @@ var _ = Describe("Broker with real Compose client", func() {
 					"bind_resource": {
 						"app_guid": "%s"
 					},
-					"parameters": "%s"
+					"parameters": "{}"
 				}`,
 				serviceID,
 				planID,
 				appGuid,
-				paramJSON,
 			))
 			req := helper.NewRequest(
 				"PUT",

--- a/integration_tests/real_api/real_api_suite_test.go
+++ b/integration_tests/real_api/real_api_suite_test.go
@@ -20,6 +20,10 @@ var (
 	newCatalog catalog.ComposeCatalog
 	logger     lager.Logger
 	brokerUrl  string
+	username   string
+	password   string
+	dbprefix   string
+	err        error
 )
 
 const (
@@ -28,20 +32,16 @@ const (
 	letters                 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
 
-var (
-	username string
-	password string
-	err      error
-)
-
 func TestSuite(t *testing.T) {
 	BeforeSuite(func() {
 
 		username = randString(randLength)
 		password = randString(randLength)
+		dbprefix = "test-suite"
 
 		os.Setenv("USERNAME", username)
 		os.Setenv("PASSWORD", password)
+		os.Setenv("DB_PREFIX", dbprefix)
 
 		newConfig, err = config.New()
 		Expect(err).ToNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -47,13 +47,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	compose, err := compose.NewClient(config.APIToken)
+	composeapi, err := compose.NewClient(config.APIToken)
 	if err != nil {
 		logger.Error("could not create composeapi client", err)
 		os.Exit(1)
 	}
 
-	brokerInstance, err := broker.New(compose, config, &newCatalog, logger)
+	account, errors := composeapi.GetAccount()
+	if len(errors) > 0 {
+		logger.Error("could not get account id", compose.SquashErrors(errors))
+		os.Exit(1)
+	}
+	config.AccountID = account.ID
+
+	brokerInstance, err := broker.New(composeapi, config, &newCatalog, logger)
 	if err != nil {
 		logger.Error("could not initialise broker", err)
 		os.Exit(1)


### PR DESCRIPTION
## What

Currently, a DB instance name managed by the broker is a plain UUID. That makes it harder for humans to recognise in Compose UI which instances are automatically provisioned by the broker. To make things a little bit easier this PR implements a DB prefix that will help to recognise which DBs are broker made.

Also - small improvement in tests: as we decided to not support user provided parameters we can test if we ignore them. 

## How to review

- sanity check
- run tests and check if you can recognise a test instance in the UI 😈 
- deploy together with (PR here)
- tag master branch `v0.1.0` after merging

## Who
Not @combor