### PR TITLE
[#147418883] Mongo TLS verify

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -26,12 +26,13 @@ const (
 )
 
 type Credentials struct {
-	Host     string `json:"host"`
-	Port     string `json:"port"`
-	Name     string `json:"name"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	URI      string `json:"uri"`
+	Host                string `json:"host"`
+	Port                string `json:"port"`
+	Name                string `json:"name"`
+	Username            string `json:"username"`
+	Password            string `json:"password"`
+	URI                 string `json:"uri"`
+	CACertificateBase64 string `json:"ca_certificate_base64"`
 }
 
 type OperationData struct {
@@ -225,12 +226,13 @@ func (b *Broker) Bind(context context.Context, instanceID, bindingID string, det
 	dbName := strings.TrimPrefix(bindingURL.Path, "/")
 
 	binding.Credentials = Credentials{
-		Host:     bindingURL.Hostname(),
-		Port:     port[0],
-		Name:     dbName,
-		Username: username,
-		Password: password,
-		URI:      bindingURL.String(),
+		Host:                bindingURL.Hostname(),
+		Port:                port[0],
+		Name:                dbName,
+		Username:            username,
+		Password:            password,
+		URI:                 bindingURL.String(),
+		CACertificateBase64: deployment.CACertificateBase64,
 	}
 
 	return binding, nil


### PR DESCRIPTION
## What

Implementation of passing of Compose MongoDB CA cert to application environment VCAP variable as a part of credentials array.  

## How to review

- deploy with https://github.com/alphagov/paas-cf/pull/977
- bind to and app
- check if you can see CA cert in VCAP_SERVICES
- make sure all tests pass ( `./scripts/run-all-tests.sh`)
- after merging increment the version by tagging master branch

## Who can review

Not @chrisfarms or @combor