### PR TITLE
[#145991105] Workaround for compose API issue for "provisioner" users

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -10,7 +10,6 @@ import (
 type Client interface {
 	GetAccount() (*composeapi.Account, []error)
 	GetClusters() (*[]composeapi.Cluster, []error)
-	GetCluster(string) (*composeapi.Cluster, []error)
 	GetClusterByName(string) (*composeapi.Cluster, []error)
 	CreateDeployment(composeapi.DeploymentParams) (*composeapi.Deployment, []error)
 	DeprovisionDeployment(string) (*composeapi.Recipe, []error)

--- a/compose/fakes/client.go
+++ b/compose/fakes/client.go
@@ -38,20 +38,6 @@ func (fcc *FakeComposeClient) GetClusters() (*[]composeapi.Cluster, []error) {
 	return &fcc.Clusters, nil
 }
 
-func (fcc *FakeComposeClient) GetCluster(clusterID string) (*composeapi.Cluster, []error) {
-	if fcc.GlobalError != nil {
-		return nil, []error{fcc.GlobalError}
-	}
-
-	for _, c := range fcc.Clusters {
-		if c.ID == clusterID {
-			return &c, nil
-		}
-	}
-
-	return nil, []error{fmt.Errorf("cluster: not found")}
-}
-
 func (fcc *FakeComposeClient) GetClusterByName(clusterName string) (*composeapi.Cluster, []error) {
 	if fcc.GlobalError != nil {
 		return nil, []error{fcc.GlobalError}


### PR DESCRIPTION
When a compose user who only has "Provisioner" access set at the enterprise level attempts to use the API to fetch cluster details via `/clusters/:id` they currently receive an "unauthorized" error.
However that same user _can_ fetch the cluster details by fetching ALL
cluster details via `/cluster`.

A ticket has been raised with compose support to track this issue which I believe is a bug: https://app.compose.io/gds/support/tickets/399870368

This change works around the issue in the meantime by using `client.GetClusters` rather than `client.GetCluster(id)` in the integration tests which appears to be the only place this API call is currently required.

### How to review

- double check `GetCluster(id)` is not required anywhere else
- check that the tests are running ok

### Who can review

Anyone but me 