### PR TITLE
[#148401459] Provide non-privileged MongoDB user and database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
+dist: trusty
+sudo: false
+
 language: go
 
 go:
 - 1.8
+
+services:
+- mongodb
+
+before_script:
+- sleep 15
 
 before_install:
 - go get github.com/onsi/ginkgo/ginkgo
@@ -13,5 +22,3 @@ install:
 script:
 - go build -v . 
 - ./scripts/run-local-tests.sh
-
-

--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ This is a work-in-progress implementation of a service broker for services provi
 `PASSWORD` - username password
 `DB_PREFIX` - a prefix that can be used to tag instances. Defaults to `compose-broker`
 `CLUSTER_NAME` - a name of your enterprise cluster if you've got one and want to use it. Defaults to hosted compose
+`ACCESS_TOKEN` - your API key for Compose.
+
+## Running tests locally
+
+The integration tests communicate with MongoDB server(s). You will need to run a MongoDB server on `localhost` before running local (non-Compose) tests.
+
+```
+docker run -p 27017:27017 --name mongo -d mongo:3.2
+./scripts/run-local-tests.sh
+```

--- a/broker/utils_test.go
+++ b/broker/utils_test.go
@@ -65,4 +65,42 @@ var _ = Describe("Broker utility functions", func() {
 			Expect(instanceName).To(Equal("trim-spaces-0f38f9c2-085c-41ec-87bf-e38b72f7fdaa"))
 		})
 	})
+
+	Describe("makeUserName", func() {
+		It("can make a user name", func() {
+			userName := makeUserName("62a334e8-5afa-7c41-92a3-a44b18eba448")
+			Expect(userName).To(Equal("user_62a334e8-5afa-7c41-92a3-a44b18eba448"))
+		})
+	})
+
+	Describe("makeDatabaseName", func() {
+		It("can make a database name", func() {
+			userName := makeDatabaseName("62a334e8-5afa-7c41-92a3-a44b18eba448")
+			Expect(userName).To(Equal("db_62a334e8-5afa-7c41-92a3-a44b18eba448"))
+		})
+	})
+
+	Describe("makeRandomPassword", func() {
+		It("can make a random password", func() {
+			By("generating strings of at least a given length", func() {
+				randomPassword, err := makeRandomPassword(10)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(randomPassword)).To(BeNumerically(">", 10))
+
+				randomPassword, err = makeRandomPassword(30)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(randomPassword)).To(BeNumerically(">", 30))
+			})
+
+			By("generating numerous different values", func() {
+				observedPasswords := map[string]bool{}
+				for i := 0; i < 100; i++ {
+					password, err := makeRandomPassword(30)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(observedPasswords).To(Not(ContainElement(password)))
+					observedPasswords[password] = true
+				}
+			})
+		})
+	})
 })

--- a/integration_tests/helper/helper.go
+++ b/integration_tests/helper/helper.go
@@ -2,11 +2,19 @@ package helper
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"time"
+
+	mgo "gopkg.in/mgo.v2"
 
 	. "github.com/onsi/gomega"
 )
@@ -34,4 +42,32 @@ func ReadResponseBody(responseBody *bytes.Buffer) []byte {
 	body, err := ioutil.ReadAll(responseBody)
 	Expect(err).ToNot(HaveOccurred())
 	return body
+}
+
+func MongoConnection(uri, caBase64 string) (*mgo.Session, error) {
+	// This is work around for https://github.com/go-mgo/mgo/issues/84
+	uri = strings.TrimSuffix(uri, "?ssl=true")
+	mongourl, err := mgo.ParseURL(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	// Compose has self-signed certs for mongo. Make sure we verify it against CA certificate brovided in binding
+	ca, err := base64.StdEncoding.DecodeString(caBase64)
+	if err != nil {
+		return nil, err
+	}
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(ca)
+
+	tlsConfig := &tls.Config{RootCAs: roots}
+	Expect(tlsConfig.InsecureSkipVerify).To(BeFalse())
+
+	mongourl.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+		return tls.Dial("tcp", addr.String(), tlsConfig)
+	}
+	mongourl.Timeout = 10 * time.Second
+	session, err := mgo.DialWithInfo(mongourl)
+
+	return session, err
 }

--- a/integration_tests/helper/helper.go
+++ b/integration_tests/helper/helper.go
@@ -2,19 +2,11 @@ package helper
 
 import (
 	"bytes"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"time"
-
-	mgo "gopkg.in/mgo.v2"
 
 	. "github.com/onsi/gomega"
 )
@@ -42,32 +34,4 @@ func ReadResponseBody(responseBody *bytes.Buffer) []byte {
 	body, err := ioutil.ReadAll(responseBody)
 	Expect(err).ToNot(HaveOccurred())
 	return body
-}
-
-func MongoConnection(uri, caBase64 string) (*mgo.Session, error) {
-	// This is work around for https://github.com/go-mgo/mgo/issues/84
-	uri = strings.TrimSuffix(uri, "?ssl=true")
-	mongourl, err := mgo.ParseURL(uri)
-	if err != nil {
-		return nil, err
-	}
-
-	// Compose has self-signed certs for mongo. Make sure we verify it against CA certificate brovided in binding
-	ca, err := base64.StdEncoding.DecodeString(caBase64)
-	if err != nil {
-		return nil, err
-	}
-	roots := x509.NewCertPool()
-	roots.AppendCertsFromPEM(ca)
-
-	tlsConfig := &tls.Config{RootCAs: roots}
-	Expect(tlsConfig.InsecureSkipVerify).To(BeFalse())
-
-	mongourl.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
-		return tls.Dial("tcp", addr.String(), tlsConfig)
-	}
-	mongourl.Timeout = 10 * time.Second
-	session, err := mgo.DialWithInfo(mongourl)
-
-	return session, err
 }

--- a/main.go
+++ b/main.go
@@ -53,10 +53,16 @@ func main() {
 	}
 
 	brokerInstance, err := broker.New(composeapi, config, newCatalog, logger)
-
 	if err != nil {
 		logger.Error("could not initialise broker", err)
 		os.Exit(1)
+	}
+
+	// The RequireTLS flag exists such that local tests can use insecure database
+	// connections. In production it must always be set to true to forbid such
+	// insecure connections.
+	if !brokerInstance.RequireTLS {
+		panic("The broker must be configured to refuse non-TLS connections.")
 	}
 
 	credentials := brokerapi.BrokerCredentials{


### PR DESCRIPTION
## What

### Creating a new non-privileged user

We wish to provide users with a user that is non-privileged and cannot retain access after credentials are refreshed. We also wish to use a non-admin database because of uncertainty over MongoDB's security model.

Ideally we would create a non-admin database when first Provisioning an instance. However as this is an asynchronous operation it cannot wait to perform this action after provisioning is complete. Instead this is done in `Bind`.

MongoDB databases and collections are created implictly the first time they are referred to. It is therefore enough that we create a user with `readWrite` (read and write) permissions on a database.

The user is named based upon the `bindID`. This means that we know the username when it comes time to delete them in `Unbind`. The user password is generated using entropy from Go's `crypto/rand` package.

We have added tests that the username and database are not `admin`, and that it cannot alter users, permissions or other databases.

### Requiring a MongoDB server for testing

The broker's `Bind` and `Unbind` now needs to connect to MongoDB. For this reason you now need a MongoDB server running to run the local (non-Compose) tests. We have added instructions for doing this to the `README.md`.

We have switched to Trusty images on Travis in order to have a modern MongoDB available for CI.

### Creating a `RequireTLS` parameter

Creating a new non-privileged user required connecting to the MongoDB database being bound to. In local testing this database will not have a valid TLS certificate and thus we introduced a `RequireTLS` boolean on the `Broker` type to control whether to require TLS when connecting.

The RDS broker has a similar `requireTLS` boolean but in Compose we have had to export this in order that the `integration_tests` package can alter its value for the local tests. 

Setting `RequireTLS` to `false` is dangerous. We have added an assertion to `main.go` to prevent the broker from starting if it is not true (if TLS is not required.) There is no test that this assertion is effective.

### Suggestions

We believe that the `integration_test` package could do with substantial refactoring to improve its structure. At present it is divided into local (non-Compose) and Compose tests, with substantial duplication and little justification for many tests being in one or the other.

A followup story should fix handling of mongo connection strings - see [broker.go#246](https://github.com/alphagov/paas-compose-broker/pull/9/files#diff-79897051d7aac1f314600a930afebe9aR246).

## How to review

Run the tests with `./scripts/run-all-tests.sh`. This PR adds instructions in `README.md`.

## Who can review

Not @dcarley @46bit.