### PR TITLE
[#147445891] Run tests in parallel.

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -5,4 +5,4 @@ if [ -z $COMPOSE_API_KEY ]; then
   export COMPOSE_API_KEY
 fi
 
-ginkgo --timeout 30m -r "$@"
+ginkgo --timeout 30m --nodes=8 -r "$@"


### PR DESCRIPTION
## What

Given most of the slowness of these tests is waiting for operations to
complete in Compose, it makes sense to run them in parallel to reduce
the overall test time.

## How to review.

Look at the PR build in concourse, and verify that it builds seccessfully, and that it is indeed quicker than previous builds.

## Who can review

Not me.