### PR TITLE
[#149558193] Decouple service name from database type

### DIFF
--- a/broker/api_test.go
+++ b/broker/api_test.go
@@ -144,26 +144,21 @@ var _ = Describe("Broker API", func() {
 
 		fakeDBProvider := enginefakes.FakeProvider{}
 
-		fakeBroker, err := broker.New(fakeComposeClient, fakeDBProvider, cfg, &catalog.ComposeCatalog{
-			Catalog: catalog.Catalog{
-				Services: []brokerapi.Service{
-					service,
-				},
-			},
-			ComposeUnits: catalog.ComposeUnits{
-				Services: []catalog.Service{
-					catalog.Service{
-						ID:   service.ID,
-						Name: service.Name,
-						Plans: []catalog.ServicePlan{
-							catalog.ServicePlan{
+		fakeBroker, err := broker.New(fakeComposeClient, fakeDBProvider, cfg, &catalog.Catalog{
+			Services: []*catalog.Service{
+				{
+					Plans: []*catalog.Plan{
+						{
+							ServicePlan: brokerapi.ServicePlan{
 								ID: service.Plans[0].ID,
-								Metadata: catalog.ServicePlanMetadata{
-									Units: 1,
-								},
+							},
+							Compose: catalog.ComposeConfig{
+								Units:        1,
+								DatabaseType: "fakedb",
 							},
 						},
 					},
+					Service: service,
 				},
 			},
 		}, logger)

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -38,14 +38,14 @@ var composeStatus2State = map[string]brokerapi.LastOperationState{
 type Broker struct {
 	Compose          compose.Client
 	Config           *config.Config
-	ComposeCatalog   *catalog.ComposeCatalog
+	Catalog          *catalog.Catalog
 	Logger           lager.Logger
 	AccountID        string
 	ClusterID        string
 	DBEngineProvider dbengine.Provider
 }
 
-func New(composeClient compose.Client, dbEngineProvider dbengine.Provider, config *config.Config, catalog *catalog.ComposeCatalog, logger lager.Logger) (*Broker, error) {
+func New(composeClient compose.Client, dbEngineProvider dbengine.Provider, config *config.Config, catalog *catalog.Catalog, logger lager.Logger) (*Broker, error) {
 
 	account, errs := composeClient.GetAccount()
 	if len(errs) > 0 {
@@ -55,7 +55,7 @@ func New(composeClient compose.Client, dbEngineProvider dbengine.Provider, confi
 	broker := Broker{
 		Compose:          composeClient,
 		Config:           config,
-		ComposeCatalog:   catalog,
+		Catalog:          catalog,
 		Logger:           logger,
 		AccountID:        account.ID,
 		DBEngineProvider: dbEngineProvider,
@@ -73,7 +73,14 @@ func New(composeClient compose.Client, dbEngineProvider dbengine.Provider, confi
 }
 
 func (b *Broker) Services(context context.Context) []brokerapi.Service {
-	return b.ComposeCatalog.Catalog.Services
+	services := []brokerapi.Service{}
+	for _, s := range b.Catalog.Services {
+		for _, p := range s.Plans {
+			s.Service.Plans = append(s.Service.Plans, p.ServicePlan)
+		}
+		services = append(services, s.Service)
+	}
+	return services
 }
 
 func (b *Broker) Provision(context context.Context, instanceID string, details brokerapi.ProvisionDetails, asyncAllowed bool) (brokerapi.ProvisionedServiceSpec, error) {
@@ -91,7 +98,7 @@ func (b *Broker) Provision(context context.Context, instanceID string, details b
 		return spec, brokerapi.ErrAsyncRequired
 	}
 
-	service, err := b.ComposeCatalog.GetService(details.ServiceID)
+	service, err := b.Catalog.GetService(details.ServiceID)
 	if err != nil {
 		return spec, err
 	}
@@ -110,8 +117,8 @@ func (b *Broker) Provision(context context.Context, instanceID string, details b
 		Name:         instanceName,
 		AccountID:    b.AccountID,
 		Datacenter:   ComposeDatacenter,
-		DatabaseType: service.Name,
-		Units:        plan.Metadata.Units,
+		DatabaseType: plan.Compose.DatabaseType,
+		Units:        plan.Compose.Units,
 		SSL:          true,
 		ClusterID:    b.ClusterID,
 	}
@@ -290,7 +297,7 @@ func (b *Broker) Update(context context.Context, instanceID string, details brok
 		return spec, brokerapi.ErrAsyncRequired
 	}
 
-	service, err := b.ComposeCatalog.GetService(details.ServiceID)
+	service, err := b.Catalog.GetService(details.ServiceID)
 	if err != nil {
 		return spec, err
 	}
@@ -318,7 +325,7 @@ func (b *Broker) Update(context context.Context, instanceID string, details brok
 
 	params := composeapi.ScalingsParams{
 		DeploymentID: deployment.ID,
-		Units:        plan.Metadata.Units,
+		Units:        plan.Compose.Units,
 	}
 
 	recipe, errs := b.Compose.SetScalings(params)

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -75,9 +75,6 @@ func New(composeClient compose.Client, dbEngineProvider dbengine.Provider, confi
 func (b *Broker) Services(context context.Context) []brokerapi.Service {
 	services := []brokerapi.Service{}
 	for _, s := range b.Catalog.Services {
-		for _, p := range s.Plans {
-			s.Service.Plans = append(s.Service.Plans, p.ServicePlan)
-		}
 		services = append(services, s.Service)
 	}
 	return services

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Broker", func() {
 			})
 
 			It("looks up the compose account ID", func() {
-				b, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.ComposeCatalog{}, nil)
+				b, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.Catalog{}, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(b.AccountID).To(Equal("1234"))
@@ -44,7 +44,7 @@ var _ = Describe("Broker", func() {
 
 			It("returns an error if looking up the account fails", func() {
 				fakeComposeClient.GlobalError = errors.New("something went wrong")
-				_, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.ComposeCatalog{}, nil)
+				_, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.Catalog{}, nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -64,7 +64,7 @@ var _ = Describe("Broker", func() {
 			})
 
 			It("leaves the cluster ID blank if no cluster name provided", func() {
-				b, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.ComposeCatalog{}, nil)
+				b, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.Catalog{}, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(b.ClusterID).To(BeEmpty())
@@ -73,7 +73,7 @@ var _ = Describe("Broker", func() {
 			It("populates the clusterID using the provided name", func() {
 				cfg.ClusterName = "cluster-two"
 
-				b, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.ComposeCatalog{}, nil)
+				b, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.Catalog{}, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(b.ClusterID).To(Equal("2"))
@@ -82,7 +82,7 @@ var _ = Describe("Broker", func() {
 			It("returns an error if the cluster ID can't be looked up", func() {
 				cfg.ClusterName = "non-existent"
 
-				_, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.ComposeCatalog{}, nil)
+				_, err := broker.New(fakeComposeClient, fakeDBEngineProvider, cfg, &catalog.Catalog{}, nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -4,81 +4,50 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/pivotal-cf/brokerapi"
 )
 
-type ComposeCatalog struct {
-	Catalog      Catalog
-	ComposeUnits ComposeUnits
-}
-
-// Catalog is an upstream Catalog struct
-type Catalog struct {
-	Services []brokerapi.Service `json:"services"`
-}
-
-type ComposeUnits struct {
-	Services []Service `json:"services"`
-}
-
 type Service struct {
-	ID    string        `json:"id"`
-	Name  string        `json:"name"`
-	Plans []ServicePlan `json:"plans"`
+	Plans []*Plan `json:"plans"`
+	brokerapi.Service
 }
 
-type ServicePlan struct {
-	ID       string              `json:"id"`
-	Metadata ServicePlanMetadata `json:"metadata,omitempty"`
+type Plan struct {
+	Compose ComposeConfig `json:"compose"`
+	brokerapi.ServicePlan
 }
 
-type ServicePlanMetadata struct {
-	Units int `json:"units,omitempty"`
+type ComposeConfig struct {
+	Units        int    `json:"units"`
+	DatabaseType string `json:"databaseType"`
 }
 
-func (c *ComposeCatalog) GetService(id string) (*Service, error) {
-	for _, service := range c.ComposeUnits.Services {
+type Catalog struct {
+	Services []*Service `json:"services"`
+}
+
+func (c *Catalog) GetService(id string) (*Service, error) {
+	for _, service := range c.Services {
 		if service.ID == id {
-			return &service, nil
+			return service, nil
 		}
 	}
 
-	return nil, fmt.Errorf("service: not found")
+	return nil, fmt.Errorf("service %v: not found", id)
 }
 
-func (s *Service) GetPlan(id string) (*ServicePlan, error) {
+func (s *Service) GetPlan(id string) (*Plan, error) {
 	for _, plan := range s.Plans {
 		if plan.ID == id {
-			return &plan, nil
+			return plan, nil
 		}
 	}
 
-	return nil, fmt.Errorf("plan: not found")
+	return nil, fmt.Errorf("plan %v: not found", id)
 }
 
-func Load(input io.Reader) (*ComposeCatalog, error) {
-	buf, err := ioutil.ReadAll(input)
-	if err != nil {
-		return nil, err
-	}
-
-	c := &ComposeCatalog{}
-
-	err = json.Unmarshal(buf, &c.Catalog)
-	if err != nil {
-		return nil, err
-	}
-
-	err = json.Unmarshal(buf, &c.ComposeUnits)
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
-}
-
-func (c *ComposeCatalog) Validate() error {
-	return nil
+func Load(input io.Reader) (*Catalog, error) {
+	var c Catalog
+	return &c, json.NewDecoder(input).Decode(&c)
 }

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -49,5 +49,13 @@ func (s *Service) GetPlan(id string) (*Plan, error) {
 
 func Load(input io.Reader) (*Catalog, error) {
 	var c Catalog
-	return &c, json.NewDecoder(input).Decode(&c)
+	if err := json.NewDecoder(input).Decode(&c); err != nil {
+		return nil, err
+	}
+	for _, s := range c.Services {
+		for _, p := range s.Plans {
+			s.Service.Plans = append(s.Service.Plans, p.ServicePlan)
+		}
+	}
+	return &c, nil
 }

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -1,0 +1,84 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	catalogJson = `
+		{
+		  "services": [{
+		    "id": "XXXX-XXXX-XXXX-XXXX",
+		    "name": "SERVICE_NAME",
+		    "plans": [{
+		      "id": "YYYY-YYYY-YYYY-YYYY",
+		      "name": "PLAN_NAME",
+		      "description": "DATABASE_DESCRIPTION",
+		      "compose": {
+		        "units": 1,
+		        "databaseType": "DATABASE_TYPE"
+		      }
+		    }]
+		  }]
+		}
+	`
+)
+
+var _ = Describe("catalog", func() {
+
+	var (
+		catalog *Catalog
+		err     error
+	)
+
+	BeforeEach(func() {
+		catalog, err = Load(strings.NewReader(catalogJson))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(catalog.Services).ToNot(BeEmpty(), "example catalog should have at least one service")
+		Expect(catalog.Services[0].Plans).ToNot(BeEmpty(), "example catalog should have at least one plan")
+	})
+
+	It("should have a service id set", func() {
+		Expect(catalog.Services[0].ID).To(Equal("XXXX-XXXX-XXXX-XXXX"))
+	})
+
+	It("should have a service name set", func() {
+		Expect(catalog.Services[0].Name).To(Equal("SERVICE_NAME"))
+	})
+
+	It("should have a plan with an id set", func() {
+		Expect(catalog.Services[0].Plans[0].ID).To(Equal("YYYY-YYYY-YYYY-YYYY"))
+	})
+
+	It("should have a plan with a name set", func() {
+		Expect(catalog.Services[0].Plans[0].Name).To(Equal("PLAN_NAME"))
+	})
+
+	It("should have a plan with compose config set", func() {
+		Expect(catalog.Services[0].Plans[0].Compose.Units).To(Equal(1), "expected units set")
+		Expect(catalog.Services[0].Plans[0].Compose.DatabaseType).To(Equal("DATABASE_TYPE"), "expected a databaseType set")
+	})
+
+	It("should expose the embedded brokerapi.Service type", func() {
+		service := catalog.Services[0]
+		brokerService := service.Service
+		Expect(brokerService).ToNot(BeNil())
+		Expect(brokerService.ID).To(Equal(service.ID))
+		Expect(brokerService.Name).To(Equal(service.Name))
+		Expect(brokerService.Plans).ToNot(BeEmpty())
+		plan := service.Plans[0]
+		brokerPlan := brokerService.Plans[0]
+		Expect(brokerPlan.ID).To(Equal(plan.ID))
+		Expect(brokerPlan.Name).To(Equal(plan.Name))
+	})
+
+})
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Catalog Suite")
+}

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -21,10 +21,13 @@
       "id": "fdfd4fc1-ce69-451c-a436-c2e2795b9abe",
       "name": "small",
       "description": "1GB Storage / 102MB RAM at $35.00/month.",
+      "compose": {
+        "units": 1,
+        "databaseType": "mongodb"
+      },
       "metadata": {
         "displayName": "Mongo Small",
         "bullets": [],
-        "units": 1,
         "costs": [{
           "amount": {
             "USD": 35
@@ -35,13 +38,13 @@
     }]
   },{
     "id": "6e9202f2-c2e1-4de8-8d4a-a8c898fc2d8c",
-    "name": "elastic_search",
+    "name": "elasticsearch",
     "bindable": true,
     "description": "Compose Elasticsearch instance",
     "requires": [],
     "tags": [
-    "elasticsearch",
-    "compose"
+      "elasticsearch",
+      "compose"
     ],
     "metadata": {
       "displayName": "Elasticsearch",
@@ -55,10 +58,13 @@
       "id": "6d051078-0913-403c-9763-1d03ecee50d9",
       "name": "tiny",
       "description": "2GB Storage / 2048MB RAM.",
+      "compose": {
+        "units": 1,
+        "databaseType": "elastic_search"
+      },
       "metadata": {
         "displayName": "Elasticsearch Tiny",
-        "bullets": [],
-        "units": 1
+        "bullets": []
       }
     }]
   }]

--- a/integration_tests/elastic_search_test.go
+++ b/integration_tests/elastic_search_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Broker Compose Integration", func() {
 			putURI := binding.Credentials.URI + "twitter/tweet/1?op_type=create"
 			putData := "{\"user\" : \"kimchy\",\"post_date\" : \"2009-11-15T14:12:12\",\"message\" : \"trying out Elasticsearch\"}"
 			request, err := http.NewRequest("PUT", putURI, strings.NewReader(putData))
+			Expect(err).NotTo(HaveOccurred())
 			request.Header.Set("Content-Type", "application/json")
 			resp, err := client.Do(request)
 			Expect(err).NotTo(HaveOccurred())

--- a/integration_tests/helper/helper.go
+++ b/integration_tests/helper/helper.go
@@ -130,7 +130,7 @@ type ServiceHelper struct {
 	InstanceID     string
 	ServiceID      string
 	PlanID         string
-	Catalog        *catalog.ComposeCatalog
+	Catalog        *catalog.Catalog
 	Cfg            *config.Config
 	Logger         lager.Logger
 	BrokerInstance *broker.Broker
@@ -293,10 +293,13 @@ func NewService(serviceID string, planID string) (s *ServiceHelper) {
 				"id": "fdfd4fc1-ce69-451c-a436-c2e2795b9abe",
 				"name": "small",
 				"description": "1GB Storage / 102MB RAM at $35.00/month.",
+				"compose": {
+					"databaseType": "mongodb",
+					"units": 1
+				},
 				"metadata": {
 					"displayName": "Mongo Small",
 					"bullets": [],
-					"units": 1,
 					"costs": [{
 						"amount": {
 							"USD": 35
@@ -307,7 +310,7 @@ func NewService(serviceID string, planID string) (s *ServiceHelper) {
 			}]
 		},{
 			"id": "6e9202f2-c2e1-4de8-8d4a-a8c898fc2d8c",
-			"name": "elastic_search",
+			"name": "elasticsearch",
 			"bindable": true,
 			"description": "Compose Elasticsearch instance",
 			"requires": [],
@@ -327,15 +330,19 @@ func NewService(serviceID string, planID string) (s *ServiceHelper) {
 				"id": "6d051078-0913-403c-9763-1d03ecee50d9",
 				"name": "tiny",
 				"description": "2GB Storage / 2048MB RAM.",
+				"compose": {
+					"databaseType": "elastic_search",
+					"units": 1
+				},
 				"metadata": {
 					"displayName": "Elasticsearch Tiny",
-					"bullets": [],
-					"units": 1
+					"bullets": []
 				}
 			}]
 		}]
 	}`))
 	Expect(err).ToNot(HaveOccurred())
+	Expect(len(s.Catalog.Services)).To(Equal(2))
 
 	s.ComposeClient, err = compose.NewClient(s.Cfg.APIToken)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## What

We want to be able to define the compose database type for plans independently from the service name seen used by tenants.

This change:

* Alters the expected catalog config so that each service plan can include some compose specific configuration data
* Stop using the service name to decide which type of database to provision or which engine to use in favour of the new `service[].plan[].compose.databaseType` value.

An plan may now look something like:

```
{
      "id": "xxxxx-xxxxx-xxxxx-xxxxxx",
      "name": "small",
      "description": "1GB Storage / 102MB RAM at $35.00/month.",
      "compose": {
        "units": 1,                   <-- compose units param
        "databaseType": "mongodb"     <-- compose database type 
      },
      "metadata": {
        "displayName": "Mongo Small",
        "bullets": [],
        "costs": [{"amount": {"USD": 35},"unit": "MONTHLY"}]
      }
}
```

## How to review

* [x] Review code
* [ ] Run the local tests
* [ ] Run the integration tests

## Who can review?

Not @chrisfarms nor @henrytk 

