### PR TITLE
[#149558193] Add elasticsearch to the deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is a work-in-progress implementation of a service broker for services provi
   curl -k -u compose-broker:unguessable https://compose-broker.${DEPLOY_ENV}.cloudfoundry-apps-domain.example.com/v2/catalog
   ```
 
-* Register the service:
+* Register the service broker:
 
   ```
    cf update-service-broker compose-broker compose-broker "$COMPOSE_BROKER_PASS" "https://compose-broker.${APPS_DNS_ZONE_NAME}"
@@ -44,6 +44,7 @@ This is a work-in-progress implementation of a service broker for services provi
 
    ```
    cf enable-service-access mongodb
+   cf enable-service-access elasticsearch
    ```
 
 ## Environmental variables


### PR DESCRIPTION
## What

In the elasticsearch work we didn't update the README instructions on how to deploy it. This change resolves that.

## How to review

* [x] Read the change and check it makes sense.
* [x] Check there are no further missing mentions of elasticsearch in the README.

## Who can review

Not @46bit.