### PR TITLE
[#151004135] Boyscouting: stop hardcoding secrets file name

### DIFF
--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -14,7 +14,7 @@ run:
     - -e
     - -c
     - |
-      export COMPOSE_API_KEY=$(awk -F':' '$1 ~ /compose_access_token/ {print $2}' ./secrets/compose-broker-secrets.yml)
+      export COMPOSE_API_KEY=$(awk -F':' '$1 ~ /compose_access_token/ {print $2}' "./secrets/$SECRETS_FILE")
       mkdir -p "${GOPATH}/src/github.com/alphagov/paas-compose-broker"
       cp -r  repo/* "${GOPATH}/src/github.com/alphagov/paas-compose-broker/"
       cd "${GOPATH}/src/github.com/alphagov/paas-compose-broker"


### PR DESCRIPTION
## What

This name is a generic parameter passed into the task[1], and therefore
doesn't need to be hardcoded.

[1] https://github.com/alphagov/paas-release-ci/blob/4bac86c27e741b0ec970441bef9846d159f7e14e/pipelines/integration-test.yml#L69

## How to review

By raising this pull request I have triggered the build that verifies it works: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/compose-broker/jobs/integration-test/builds/40. You're welcome.

## Who

Anyone but me.