### PR TITLE
[#153170827] Fix MongoDB bind/unbind

### DIFF
--- a/dbengine/db_engine.go
+++ b/dbengine/db_engine.go
@@ -8,6 +8,7 @@ type Credentials struct {
 	Password            string `json:"password"`
 	URI                 string `json:"uri"`
 	CACertificateBase64 string `json:"ca_certificate_base64"`
+	AuthSource          string `json:"auth_source"`
 }
 
 type DBEngine interface {

--- a/dbengine/mongo_engine.go
+++ b/dbengine/mongo_engine.go
@@ -87,6 +87,7 @@ func newMongoSession(credentials *Credentials) (*mgo.Session, error) {
 		Timeout:  10 * time.Second,
 		Username: credentials.Username,
 		Password: credentials.Password,
+		Source:   credentials.AuthSource,
 		DialServer: func(addr *mgo.ServerAddr) (net.Conn, error) {
 			conn, err := tls.Dial("tcp", addr.String(), tlsConfig)
 			return conn, err
@@ -114,6 +115,8 @@ func (e *MongoEngine) getMasterCredentials() (*Credentials, error) {
 		return nil, fmt.Errorf("no deployment provided: cannot parse the connection string")
 	} else if len(e.deployment.Connection.Direct) < 1 {
 		return nil, fmt.Errorf("failed to get connection string")
+	} else if e.deployment.Connection.Direct[0] == "" {
+		return nil, fmt.Errorf("connection string is empty")
 	}
 
 	mongoURL, err := url.Parse(e.deployment.Connection.Direct[0])
@@ -133,5 +136,6 @@ func (e *MongoEngine) getMasterCredentials() (*Credentials, error) {
 		Password:            password,
 		Name:                strings.Split(mongoURL.EscapedPath(), "/")[1],
 		CACertificateBase64: e.deployment.CACertificateBase64,
+		AuthSource:          mongoURL.Query().Get("authSource"),
 	}, nil
 }

--- a/dbengine/mongo_engine_test.go
+++ b/dbengine/mongo_engine_test.go
@@ -1,0 +1,84 @@
+package dbengine
+
+import (
+	composeapi "github.com/compose/gocomposeapi"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MongoDB", func() {
+
+	Context("getMasterCredentials", func() {
+
+		It("should parse single-host master connection string", func() {
+			engine := NewMongoEngine(&composeapi.Deployment{
+				Connection: composeapi.ConnectionStrings{
+					Direct: []string{"mongodb://user:password@test-c00.2.compose.direct:17445/compose?authSource=admin&ssl=true"},
+				},
+			})
+			creds, err := engine.getMasterCredentials()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(creds.Username).To(Equal("user"))
+			Expect(creds.Password).To(Equal("password"))
+			Expect(creds.Host).To(Equal("test-c00.2.compose.direct"))
+			Expect(creds.Port).To(Equal("17445"))
+			Expect(creds.Name).To(Equal("compose"))
+			Expect(creds.AuthSource).To(Equal("admin"))
+		})
+
+		It("should parse multi-host master connection string", func() {
+			engine := NewMongoEngine(&composeapi.Deployment{
+				Connection: composeapi.ConnectionStrings{
+					Direct: []string{"mongodb://user:password@test-c00.2.compose.direct:17445,test-c00.0.compose.direct:17445/compose?authSource=admin&ssl=true"},
+				},
+			})
+			creds, err := engine.getMasterCredentials()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(creds.Username).To(Equal("user"))
+			Expect(creds.Password).To(Equal("password"))
+			Expect(creds.Host).To(Equal("test-c00.2.compose.direct"))
+			Expect(creds.Port).To(Equal("17445"))
+			Expect(creds.Name).To(Equal("compose"))
+			Expect(creds.AuthSource).To(Equal("admin"))
+		})
+
+		It("should parse if there is no auth source", func() {
+			engine := NewMongoEngine(&composeapi.Deployment{
+				Connection: composeapi.ConnectionStrings{
+					Direct: []string{"mongodb://user:password@test-c00.2.compose.direct:17445,test-c00.0.compose.direct:17445/compose?ssl=true"},
+				},
+			})
+			creds, err := engine.getMasterCredentials()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(creds.Username).To(Equal("user"))
+			Expect(creds.Password).To(Equal("password"))
+			Expect(creds.Host).To(Equal("test-c00.2.compose.direct"))
+			Expect(creds.Port).To(Equal("17445"))
+			Expect(creds.Name).To(Equal("compose"))
+			Expect(creds.AuthSource).To(Equal(""))
+		})
+
+		It("should fail to parse invalid master connection string", func() {
+			engine := NewMongoEngine(&composeapi.Deployment{
+				Connection: composeapi.ConnectionStrings{
+					Direct: []string{"%gh&%ij"},
+				},
+			})
+			_, err := engine.getMasterCredentials()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail to parse empty connection string", func() {
+			engine := NewMongoEngine(&composeapi.Deployment{
+				Connection: composeapi.ConnectionStrings{
+					Direct: []string{""},
+				},
+			})
+			creds, err := engine.getMasterCredentials()
+			Expect(err).Should(HaveOccurred())
+			Expect(creds).To(BeNil())
+		})
+
+	})
+
+})


### PR DESCRIPTION
## What

Set the authentication source when connecting to a MongoDB cluster

We start to parse the authSource parameter passed in the MongoDB connection string. We use the authentication source to connect to the MongoDB cluster to create/delete users and we send back this parameter for new service bindings.

Our authentication against an existing deployment stopped working at one point and it turned out we are using the wrong authentication source (database).
Compose passes back an authSource paramater in the connection string which we didn't use. We suspect the authentication source was originally the same as the database that we connected to.

Currently a connection string looks like this:
```mongodb://user:password@test-c00.2.compose.direct:17445/compose?authSource=admin&ssl=true```
Originally it was like:
```mongodb://user:password@test-c00.2.compose.direct:17445/admin?ssl=true```

'compose' is the database name we connect to, but we have to use the 'admin' database as the authentication source. The mgo library by default falls back to the connection database if the auth source is empty.

The compose documentation also says: "Users and authentication are handled by the admin database". See https://help.compose.com/docs/mongodb-connecting-to#section-connection-string-parameters.

## How to review

Please test it as part of https://github.com/alphagov/paas-cf/pull/1139.

## Who can review

Not @camelpunch or @bandesz